### PR TITLE
MAINT: fix regressive pyqt pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - lightpath = lightpath.main:entrypoint
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -29,7 +29,7 @@ requirements:
     - pcdsdevices >=3.4.0
     - prettytable
     - pydm
-    - pyqt <5.15.0
+    - pyqt >=5
     - qtawesome
     - qtpy
     - typhos >=1.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pcdshub/lightpath/archive/v{{ version }}.tar.gz
-  sha256: ea489d6f74eaebe4db500af469fb3ce8c7862ad1030aeadf66caea2d26e8e7b8
+  sha256: be2c5107c28d0a59fa50bc17f3061ac94ec5bb8222af8ebdfd718e42aba80b58
 
 build:
   entry_points:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
This PR removes the < pin and replaces it with a normal >= pin

This pin will continue to cause environment build errors if we leave it alone.
The issues related to using more recent versions of pyqt are no longer present, so the pin should be lifted.

The library is not tested against pyqt4 so it is excluded in the new pin here

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
