### PR TITLE
BLD: add extra.feedstock-name as per knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About lightpath-suite-feedstock
-===============================
+About lightpath-feedstock
+=========================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/lightpath-feedstock/blob/main/LICENSE.txt)
 
@@ -34,10 +34,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-lightpath-green.svg)](https://anaconda.org/conda-forge/lightpath) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/lightpath.svg)](https://anaconda.org/conda-forge/lightpath) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/lightpath.svg)](https://anaconda.org/conda-forge/lightpath) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/lightpath.svg)](https://anaconda.org/conda-forge/lightpath) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-lightpath--base-green.svg)](https://anaconda.org/conda-forge/lightpath-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/lightpath-base.svg)](https://anaconda.org/conda-forge/lightpath-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/lightpath-base.svg)](https://anaconda.org/conda-forge/lightpath-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/lightpath-base.svg)](https://anaconda.org/conda-forge/lightpath-base) |
 
-Installing lightpath-suite
-==========================
+Installing lightpath
+====================
 
-Installing `lightpath-suite` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `lightpath` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -123,17 +123,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating lightpath-suite-feedstock
-==================================
+Updating lightpath-feedstock
+============================
 
-If you would like to improve the lightpath-suite recipe or build a new
+If you would like to improve the lightpath recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/lightpath-suite-feedstock are
+Note that all branches in the conda-forge/lightpath-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/pcdshub/lightpath/archive/v{{ version }}.tar.gz
-  sha256: 7c617fb4a13341414ee1fbc91bbb00f7244e5638a63d75b5953d636bc8a97891
+  sha256: f327d5c5c9eb1f0199987b41b5a62a981941abd57d2e90d013e1f76a60e8809f
 
 build:
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   entry_points:
     - lightpath = lightpath.main:entrypoint
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -71,5 +71,6 @@ about:
   summary: Linac Coherent Light Source (LCLS) beamline configuration and control
 
 extra:
+  feedstock-name: lightpath
   recipe-maintainers:
     - conda-forge/pcdsdevices


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~[ ] Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Lightpath-base was not appearing after our last modification to this feedstock.  After consulting the [knowledge base article ](https://conda-forge.org/docs/maintainer/knowledge_base/#common-pitfalls-with-outputs)I will see if changing the extra.feedstock-name remedies this problem
